### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # EʅɾαՇισ
 <a href="https://liamswayne.github.io/elratio/security.mp4">
     <img src="https://img.shields.io/badge/Visitor_IP_address-66.122.23.197-blue" height="25">


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/Elratio/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=LiamSwayne&project=Elratio&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
